### PR TITLE
添加示例文档

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -1,0 +1,11 @@
+# 示例文档
+
+这是一个测试文件，用于测试 GitHub 自动分配审阅者的功能。
+
+## 功能说明
+
+当创建新的 Pull Request 时，系统会自动将仓库所有者设置为审阅者。
+
+## 工作原理
+
+这个功能通过 GitHub Actions 工作流实现，配置文件位于 `.github/workflows/auto-assign-reviewer.yml`。


### PR DESCRIPTION
这个 PR 添加了示例文档文件，用于测试 GitHub 自动分配审阅者功能。该功能应当会自动将仓库所有者设置为 PR 的审阅者。